### PR TITLE
Adjust vav-vav/vav-yod/yod-yod set width in Sans/Rashi for #39

### DIFF
--- a/sources/NotoRashiHebrew.glyphs
+++ b/sources/NotoRashiHebrew.glyphs
@@ -3,7 +3,6 @@
 DisplayStrings = (
 "/tsere-hb",
 "/tsadi-hb",
-"/yod-hb",
 "/shin-hb",
 "/sindot-hb",
 "/shindot-hb",
@@ -2819,7 +2818,7 @@ unicode = 200F;
 },
 {
 glyphname = "vavvav-hb";
-lastChange = "2020-01-12 13:53:32 +0000";
+lastChange = "2024-02-27 19:26:35 +0000";
 layers = (
 {
 anchors = (
@@ -2852,14 +2851,14 @@ components = (
 {
 alignment = -1;
 name = "vav-hb";
-transform = "{1, 0, 0, 1, 224, 0}";
+transform = "{1, 0, 0, 1, 261, 0}";
 },
 {
 name = "vav-hb";
 }
 );
 layerId = "B853D75E-14CD-4000-B7A0-02101202F42C";
-width = 485;
+width = 522;
 },
 {
 anchors = (
@@ -2931,7 +2930,7 @@ components = (
 {
 alignment = -1;
 name = "vav-hb";
-transform = "{1, 0, 0, 1, 264, 0}";
+transform = "{1, 0, 0, 1, 282, 0}";
 },
 {
 alignment = -1;
@@ -2939,7 +2938,7 @@ name = "vav-hb";
 }
 );
 layerId = "E2314B6E-5E7F-4CD2-8B1C-CC369A56056B";
-width = 545.25301;
+width = 564;
 }
 );
 note = vavvav;
@@ -2947,7 +2946,7 @@ unicode = 05F0;
 },
 {
 glyphname = "vavyod-hb";
-lastChange = "2020-01-12 13:53:32 +0000";
+lastChange = "2024-02-27 18:51:21 +0000";
 layers = (
 {
 anchors = (
@@ -2960,14 +2959,14 @@ components = (
 {
 alignment = -1;
 name = "vav-hb";
-transform = "{1, 0, 0, 1, 210, 0}";
+transform = "{1, 0, 0, 1, 240, 0}";
 },
 {
 name = "yod-hb";
 }
 );
 layerId = "B853D75E-14CD-4000-B7A0-02101202F42C";
-width = 471;
+width = 501;
 },
 {
 anchors = (
@@ -2999,7 +2998,7 @@ components = (
 {
 alignment = -1;
 name = "vav-hb";
-transform = "{1, 0, 0, 1, 254, 0}";
+transform = "{1, 0, 0, 1, 268, 0}";
 },
 {
 alignment = -1;
@@ -3007,7 +3006,7 @@ name = "yod-hb";
 }
 );
 layerId = "E2314B6E-5E7F-4CD2-8B1C-CC369A56056B";
-width = 535.27015;
+width = 550;
 }
 );
 note = vavyod;
@@ -3015,7 +3014,7 @@ unicode = 05F1;
 },
 {
 glyphname = "yodyod-hb";
-lastChange = "2021-07-05 00:36:29 +0000";
+lastChange = "2024-02-27 19:50:07 +0000";
 layers = (
 {
 anchors = (
@@ -3028,14 +3027,14 @@ components = (
 {
 alignment = -1;
 name = "yod-hb";
-transform = "{1, 0, 0, 1, 210, 0}";
+transform = "{1, 0, 0, 1, 240, 0}";
 },
 {
 name = "yod-hb";
 }
 );
 layerId = "B853D75E-14CD-4000-B7A0-02101202F42C";
-width = 440;
+width = 480;
 },
 {
 anchors = (
@@ -4394,7 +4393,7 @@ unicode = 05D4;
 },
 {
 glyphname = "vav-hb";
-lastChange = "2024-02-27 00:22:22 +0000";
+lastChange = "2024-02-27 18:20:34 +0000";
 layers = (
 {
 anchors = (
@@ -4574,7 +4573,7 @@ nodes = (
 );
 }
 );
-width = 281.62789;
+width = 282;
 }
 );
 unicode = 05D5;
@@ -5398,7 +5397,7 @@ unicode = 05D8;
 },
 {
 glyphname = "yod-hb";
-lastChange = "2023-11-23 13:32:01 +0000";
+lastChange = "2024-02-27 18:36:08 +0000";
 layers = (
 {
 anchors = (
@@ -5632,7 +5631,7 @@ nodes = (
 );
 }
 );
-width = 268.23911;
+width = 268;
 }
 );
 unicode = 05D9;

--- a/sources/NotoSansHebrew.glyphs
+++ b/sources/NotoSansHebrew.glyphs
@@ -1,5 +1,5 @@
 {
-.appVersion = "3225";
+.appVersion = "3241";
 DisplayStrings = (
 "/he-hb/lamed-hb/yod-hb/lamed-hb/he-hb/space/shin-hb/space/sindot-hb/space/holam-hb/space/holamhaser-hb/space/lamed-hb/vav-hb/holamhaser-hb/space/kaf-hb/vav-hb/kaf-hb/bet-hb/het-hb/siluqleft-hb/hatafsegol_zerowidthjoiner_siluqleft-hb/hatafpatah_zerowidthjoiner_siluqleft-hb/hatafqamats_zerowidthjoiner_siluqleft-hb",
 "/segolta-hb",
@@ -236,6 +236,7 @@ Tag = wdth;
 date = "2021-08-01 17:52:00 +0000";
 designer = "Monotype Design Team";
 designerURL = "http://www.monotype.com/studio";
+disablesAutomaticAlignment = 1;
 disablesNiceNames = 1;
 familyName = "Noto Sans Hebrew";
 featurePrefixes = (
@@ -25254,7 +25255,7 @@ width = 547;
 },
 {
 glyphname = "vavvav-hb";
-lastChange = "2016-07-07 18:36:03 +0000";
+lastChange = "2024-02-28 01:29:31 +0000";
 layers = (
 {
 anchors = (
@@ -25310,27 +25311,27 @@ width = 412;
 anchors = (
 {
 name = bottom;
-position = "{140, 0}";
+position = "{130, 0}";
 },
 {
 name = bottomleft;
-position = "{0, 0}";
+position = "{-10, 0}";
 },
 {
 name = caret_1;
-position = "{280, 0}";
+position = "{270, 0}";
 },
 {
 name = center;
-position = "{0, 300}";
+position = "{-10, 300}";
 },
 {
 name = top;
-position = "{140, 536}";
+position = "{130, 536}";
 },
 {
 name = topleft;
-position = "{122, 536}";
+position = "{112, 536}";
 }
 );
 layerId = "0C04772A-F31D-4E86-90EF-3402D1EA39CA";
@@ -25338,49 +25339,49 @@ paths = (
 {
 closed = 1;
 nodes = (
-"465 0 LINE",
-"465 592 LINE",
-"375 592 LINE",
-"375 0 LINE"
+"435 0 LINE",
+"435 592 LINE",
+"345 592 LINE",
+"345 0 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"185 0 LINE",
-"185 592 LINE",
-"95 592 LINE",
-"95 0 LINE"
+"175 0 LINE",
+"175 592 LINE",
+"85 592 LINE",
+"85 0 LINE"
 );
 }
 );
-width = 560;
+width = 520;
 },
 {
 anchors = (
 {
 name = bottom;
-position = "{145, 0}";
+position = "{155, 0}";
 },
 {
 name = bottomleft;
-position = "{0, 0}";
+position = "{10, 0}";
 },
 {
 name = caret_1;
-position = "{280, 0}";
+position = "{290, 0}";
 },
 {
 name = center;
-position = "{-14, 303}";
+position = "{-4, 303}";
 },
 {
 name = top;
-position = "{145, 546}";
+position = "{155, 546}";
 },
 {
 name = topleft;
-position = "{103, 546}";
+position = "{113, 546}";
 }
 );
 layerId = "206B8059-80C9-426C-870D-7DCC5D63B771";
@@ -25388,49 +25389,49 @@ paths = (
 {
 closed = 1;
 nodes = (
-"510 0 LINE",
-"510 602 LINE",
-"360 602 LINE",
-"360 0 LINE"
+"540 0 LINE",
+"540 602 LINE",
+"390 602 LINE",
+"390 0 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"220 0 LINE",
-"220 602 LINE",
-"70 602 LINE",
-"70 0 LINE"
+"230 0 LINE",
+"230 602 LINE",
+"80 602 LINE",
+"80 0 LINE"
 );
 }
 );
-width = 580;
+width = 620;
 },
 {
 anchors = (
 {
 name = bottom;
-position = "{171, 0}";
+position = "{166, 0}";
 },
 {
 name = bottomleft;
-position = "{20, 0}";
+position = "{15, 0}";
 },
 {
 name = caret_1;
-position = "{280, 0}";
+position = "{275, 0}";
 },
 {
 name = center;
-position = "{-23, 306}";
+position = "{-28, 306}";
 },
 {
 name = top;
-position = "{171, 553}";
+position = "{166, 553}";
 },
 {
 name = topleft;
-position = "{119, 553}";
+position = "{114, 553}";
 }
 );
 layerId = "3FB868F8-5CDC-4A46-BA32-95627737ABE0";
@@ -25438,49 +25439,49 @@ paths = (
 {
 closed = 1;
 nodes = (
-"609 0 LINE",
-"609 609 LINE",
-"417 609 LINE",
-"417 0 LINE"
+"594 0 LINE",
+"594 609 LINE",
+"402 609 LINE",
+"402 0 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"267 0 LINE",
-"267 609 LINE",
-"75 609 LINE",
-"75 0 LINE"
+"262 0 LINE",
+"262 609 LINE",
+"70 609 LINE",
+"70 0 LINE"
 );
 }
 );
-width = 684;
+width = 664;
 },
 {
 anchors = (
 {
 name = bottom;
-position = "{103, 0}";
+position = "{88, 0}";
 },
 {
 name = bottomleft;
-position = "{0, 0}";
+position = "{-15, 0}";
 },
 {
 name = caret_1;
-position = "{206, 0}";
+position = "{191, 0}";
 },
 {
 name = center;
-position = "{12, 296}";
+position = "{-3, 296}";
 },
 {
 name = top;
-position = "{103, 528}";
+position = "{88, 528}";
 },
 {
 name = topleft;
-position = "{98, 528}";
+position = "{83, 528}";
 }
 );
 layerId = "BD31AAF9-E65B-4A30-ACC0-7018B0C27C60";
@@ -25488,49 +25489,49 @@ paths = (
 {
 closed = 1;
 nodes = (
-"322 0 LINE",
-"322 584 LINE",
-"296 584 LINE",
-"296 0 LINE"
+"277 0 LINE",
+"277 584 LINE",
+"251 584 LINE",
+"251 0 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"116 0 LINE",
-"116 584 LINE",
-"90 584 LINE",
-"90 0 LINE"
+"101 0 LINE",
+"101 584 LINE",
+"75 584 LINE",
+"75 0 LINE"
 );
 }
 );
-width = 412;
+width = 352;
 },
 {
 anchors = (
 {
 name = bottom;
-position = "{140, 0}";
+position = "{110, 0}";
 },
 {
 name = bottomleft;
-position = "{0, 0}";
+position = "{-30, 0}";
 },
 {
 name = caret_1;
-position = "{280, 0}";
+position = "{250, 0}";
 },
 {
 name = center;
-position = "{0, 300}";
+position = "{-30, 300}";
 },
 {
 name = top;
-position = "{140, 536}";
+position = "{110, 536}";
 },
 {
 name = topleft;
-position = "{122, 536}";
+position = "{92, 536}";
 }
 );
 layerId = "E193C3F6-581C-4255-BA06-39B2C55FEA85";
@@ -25538,49 +25539,49 @@ paths = (
 {
 closed = 1;
 nodes = (
-"465 0 LINE",
-"465 592 LINE",
-"375 592 LINE",
-"375 0 LINE"
+"363 0 LINE",
+"363 592 LINE",
+"273 592 LINE",
+"273 0 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"185 0 LINE",
-"185 592 LINE",
-"95 592 LINE",
-"95 0 LINE"
+"155 0 LINE",
+"155 592 LINE",
+"65 592 LINE",
+"65 0 LINE"
 );
 }
 );
-width = 560;
+width = 428;
 },
 {
 anchors = (
 {
 name = bottom;
-position = "{170, 0}";
+position = "{135, 0}";
 },
 {
 name = bottomleft;
-position = "{25, 0}";
+position = "{-10, 0}";
 },
 {
 name = caret_1;
-position = "{305, 0}";
+position = "{270, 0}";
 },
 {
 name = center;
-position = "{11, 303}";
+position = "{-24, 303}";
 },
 {
 name = top;
-position = "{170, 546}";
+position = "{135, 546}";
 },
 {
 name = topleft;
-position = "{128, 546}";
+position = "{93, 546}";
 }
 );
 layerId = "4D9C3FAB-40EB-4CCF-A752-6D6FE9920038";
@@ -25588,49 +25589,49 @@ paths = (
 {
 closed = 1;
 nodes = (
-"535 0 LINE",
-"535 602 LINE",
-"385 602 LINE",
-"385 0 LINE"
+"454 0 LINE",
+"454 602 LINE",
+"304 602 LINE",
+"304 0 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"245 0 LINE",
-"245 602 LINE",
-"95 602 LINE",
-"95 0 LINE"
+"210 0 LINE",
+"210 602 LINE",
+"60 602 LINE",
+"60 0 LINE"
 );
 }
 );
-width = 630;
+width = 514;
 },
 {
 anchors = (
 {
 name = bottom;
-position = "{171, 0}";
+position = "{151, 0}";
 },
 {
 name = bottomleft;
-position = "{20, 0}";
+position = "{0, 0}";
 },
 {
 name = caret_1;
-position = "{280, 0}";
+position = "{260, 0}";
 },
 {
 name = center;
-position = "{-23, 306}";
+position = "{-43, 306}";
 },
 {
 name = top;
-position = "{171, 553}";
+position = "{151, 553}";
 },
 {
 name = topleft;
-position = "{119, 553}";
+position = "{99, 553}";
 }
 );
 layerId = "AD6F6DAA-2D58-4E1D-98AF-ACAAF76D7B9E";
@@ -25638,23 +25639,23 @@ paths = (
 {
 closed = 1;
 nodes = (
-"609 0 LINE",
-"609 609 LINE",
-"417 609 LINE",
-"417 0 LINE"
+"505 0 LINE",
+"505 609 LINE",
+"313 609 LINE",
+"313 0 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"267 0 LINE",
-"267 609 LINE",
-"75 609 LINE",
-"75 0 LINE"
+"247 0 LINE",
+"247 609 LINE",
+"55 609 LINE",
+"55 0 LINE"
 );
 }
 );
-width = 684;
+width = 560;
 }
 );
 note = vavvav;


### PR DESCRIPTION
Sans

 Layers adjusted:
  - double-vav: regular, semibold, bold, light condensed, condensed, semibold condensed, bold condensed

 Weights corrected:

  - Black, ExtraCondensed-Black, Bold, ExtraCondensed-Bold, ExtraBold, ExtraCondensed-ExtraBold, ExtraLight, ExtraCondensed-ExtraLight, Light, ExtraCondensed-Light, Medium, ExtraCondensed-Medium, Regular, ExtraCondensed-Regular, SemiBold, ExtraCondensed-SemiBold, ExtraCondensed-Thin, Condensed-Black, SemiCondensed-Black, Condensed-Bold, SemiCondensed-Bold, Condensed-ExtraBold, SemiCondensed-ExtraBold, Condensed-ExtraLight, SemiCondensed-ExtraLight, Condensed-Light, SemiCondensed-Light, Condensed-Medium, SemiCondensed-Medium, Condensed-Regular, SemiCondensed-Regular, Condensed-SemiBold, SemiCondensed-SemiBold, Condensed-Thin, SemiCondensed-Thin

  - (i.e., every weight except Thin)

Rashi

 Layers adjusted:

  - double-vav: light, regular

  - vav-yod: light, regular

  - double-yod: light

 Weights corrected:

  - Bold, ExtraBold, ExtraLight, Light, Medium, Regular, SemiBold, Thin

  - (i.e., every weight except Black)

Tested by regenerating ttf's via Glyphs App > File > Export, then running hb-view commands as per issue, but extended to test for every weight of .ttf font generated for all 3 families
(Sans/Rashi/Serif).  After fixes, generated .png files show good alignment in all weights of all 3 families.