### PR TITLE
Correct bottom anchor x position for vav-vav/yod-yod digraphs (#38)

### DIFF
--- a/sources/NotoRashiHebrew.glyphs
+++ b/sources/NotoRashiHebrew.glyphs
@@ -2818,13 +2818,13 @@ unicode = 200F;
 },
 {
 glyphname = "vavvav-hb";
-lastChange = "2024-02-27 19:26:35 +0000";
+lastChange = "2024-02-28 23:33:02 +0000";
 layers = (
 {
 anchors = (
 {
 name = bottom;
-position = "{170, 0}";
+position = "{290, 0}";
 },
 {
 name = bottomleft;
@@ -2864,7 +2864,7 @@ width = 522;
 anchors = (
 {
 name = bottom;
-position = "{220, 0}";
+position = "{316, 0}";
 },
 {
 name = bottomleft;
@@ -2903,7 +2903,7 @@ width = 582;
 anchors = (
 {
 name = bottom;
-position = "{196, 0}";
+position = "{273, 0}";
 },
 {
 name = bottomleft;
@@ -3014,10 +3014,14 @@ unicode = 05F1;
 },
 {
 glyphname = "yodyod-hb";
-lastChange = "2024-02-27 19:50:07 +0000";
+lastChange = "2024-02-28 23:31:41 +0000";
 layers = (
 {
 anchors = (
+{
+name = bottom;
+position = "{250, 0}";
+},
 {
 name = caret_1;
 position = "{250, 0}";
@@ -3039,6 +3043,10 @@ width = 480;
 {
 anchors = (
 {
+name = bottom;
+position = "{342, 0}";
+},
+{
 name = caret_1;
 position = "{250, 0}";
 }
@@ -3057,6 +3065,10 @@ width = 590;
 },
 {
 anchors = (
+{
+name = bottom;
+position = "{297, 0}";
+},
 {
 name = caret_1;
 position = "{270, 0}";
@@ -4393,7 +4405,7 @@ unicode = 05D4;
 },
 {
 glyphname = "vav-hb";
-lastChange = "2024-02-27 18:20:34 +0000";
+lastChange = "2024-02-28 23:29:34 +0000";
 layers = (
 {
 anchors = (

--- a/sources/NotoSansHebrew.glyphs
+++ b/sources/NotoSansHebrew.glyphs
@@ -25255,13 +25255,13 @@ width = 547;
 },
 {
 glyphname = "vavvav-hb";
-lastChange = "2024-02-28 01:29:31 +0000";
+lastChange = "2024-02-28 22:25:16 +0000";
 layers = (
 {
 anchors = (
 {
 name = bottom;
-position = "{103, 0}";
+position = "{206, 0}";
 },
 {
 name = bottomleft;
@@ -25311,7 +25311,7 @@ width = 412;
 anchors = (
 {
 name = bottom;
-position = "{130, 0}";
+position = "{260, 0}";
 },
 {
 name = bottomleft;
@@ -25361,7 +25361,7 @@ width = 520;
 anchors = (
 {
 name = bottom;
-position = "{155, 0}";
+position = "{310, 0}";
 },
 {
 name = bottomleft;
@@ -25411,7 +25411,7 @@ width = 620;
 anchors = (
 {
 name = bottom;
-position = "{166, 0}";
+position = "{332, 0}";
 },
 {
 name = bottomleft;
@@ -25461,7 +25461,7 @@ width = 664;
 anchors = (
 {
 name = bottom;
-position = "{88, 0}";
+position = "{176, 0}";
 },
 {
 name = bottomleft;
@@ -25511,7 +25511,7 @@ width = 352;
 anchors = (
 {
 name = bottom;
-position = "{110, 0}";
+position = "{214, 0}";
 },
 {
 name = bottomleft;
@@ -25561,7 +25561,7 @@ width = 428;
 anchors = (
 {
 name = bottom;
-position = "{135, 0}";
+position = "{257, 0}";
 },
 {
 name = bottomleft;
@@ -25611,7 +25611,7 @@ width = 514;
 anchors = (
 {
 name = bottom;
-position = "{151, 0}";
+position = "{280, 0}";
 },
 {
 name = bottomleft;
@@ -25823,10 +25823,14 @@ unicode = 05F1;
 },
 {
 glyphname = "yodyod-hb";
-lastChange = "2016-07-07 18:36:03 +0000";
+lastChange = "2024-02-28 22:21:03 +0000";
 layers = (
 {
 anchors = (
+{
+name = bottom;
+position = "{184, 0}";
+},
 {
 name = caret_1;
 position = "{176, 0}";
@@ -25847,6 +25851,10 @@ width = 362;
 {
 anchors = (
 {
+name = bottom;
+position = "{238, 0}";
+},
+{
 name = caret_1;
 position = "{250, 0}";
 }
@@ -25865,6 +25873,10 @@ width = 470;
 },
 {
 anchors = (
+{
+name = bottom;
+position = "{288, 0}";
+},
 {
 name = caret_1;
 position = "{250, 0}";
@@ -25885,6 +25897,10 @@ width = 570;
 {
 anchors = (
 {
+name = bottom;
+position = "{310, 0}";
+},
+{
 name = caret_1;
 position = "{250, 0}";
 }
@@ -25903,6 +25919,10 @@ width = 614;
 },
 {
 anchors = (
+{
+name = bottom;
+position = "{154, 0}";
+},
 {
 name = caret_1;
 position = "{176, 0}";
@@ -25923,6 +25943,10 @@ width = 302;
 {
 anchors = (
 {
+name = bottom;
+position = "{198, 0}";
+},
+{
 name = caret_1;
 position = "{250, 0}";
 }
@@ -25942,6 +25966,10 @@ width = 390;
 {
 anchors = (
 {
+name = bottom;
+position = "{241, 0}";
+},
+{
 name = caret_1;
 position = "{250, 0}";
 }
@@ -25960,6 +25988,10 @@ width = 464;
 },
 {
 anchors = (
+{
+name = bottom;
+position = "{258, 0}";
+},
 {
 name = caret_1;
 position = "{250, 0}";

--- a/sources/NotoSerifHebrew.glyphs
+++ b/sources/NotoSerifHebrew.glyphs
@@ -1,5 +1,5 @@
 {
-.appVersion = "3109";
+.appVersion = "3241";
 DisplayStrings = (
 "/vav-hb/holam-hb/space/vav-hb/holamhaser-hb/shin-hb/sindot-hb/space/holam-hb/lamed-hb/vav-hb/holamhaser-hb/space/vav-hb/holam-hb/kaf-hb/vav-hb/kaf-hb/bet-hb/space/he-hb/shin-hb/bet-hb/yod-hb/tet-hb/space/he-hb/resh-hb/alef-hb/shin-hb/vav-hb/finalnun-hb",
 "/het-hb/alefqamats-hb/siluqleft-hb/het-hb/hatafsegol-hb/uni200D/siluqleft-hb/het-hb/hatafpatah-hb/uni200D/siluqleft-hb/het-hb/hatafqamats-hb/uni200D/siluqleft-hb",
@@ -206,12 +206,12 @@ name = licenseURL;
 value = "https://scripts.sil.org/OFL";
 },
 {
-name = vendorID;
-value = GOOG;
-},
-{
 name = trademark;
 value = "Noto is a trademark of Google LLC.";
+},
+{
+name = vendorID;
+value = GOOG;
 },
 {
 name = versionString;
@@ -37396,13 +37396,13 @@ unicode = 200F;
 },
 {
 glyphname = "vavvav-hb";
-lastChange = "2016-07-07 21:10:59 +0000";
+lastChange = "2024-02-28 23:12:08 +0000";
 layers = (
 {
 anchors = (
 {
 name = bottom;
-position = "{215, 0}";
+position = "{378, 0}";
 },
 {
 name = bottomleft;
@@ -37494,7 +37494,7 @@ width = 652;
 anchors = (
 {
 name = bottom;
-position = "{170, 0}";
+position = "{306, 0}";
 },
 {
 name = bottomleft;
@@ -37586,7 +37586,7 @@ width = 544;
 anchors = (
 {
 name = bottom;
-position = "{220, 0}";
+position = "{374, 0}";
 },
 {
 name = bottomleft;
@@ -37678,7 +37678,7 @@ width = 614;
 anchors = (
 {
 name = bottom;
-position = "{170, 0}";
+position = "{190, 0}";
 },
 {
 name = bottomleft;
@@ -37770,7 +37770,7 @@ width = 332;
 anchors = (
 {
 name = bottom;
-position = "{215, 0}";
+position = "{264, 0}";
 },
 {
 name = bottomleft;
@@ -37862,7 +37862,7 @@ width = 432;
 anchors = (
 {
 name = bottom;
-position = "{230, 0}";
+position = "{280, 0}";
 },
 {
 name = bottomleft;
@@ -38078,10 +38078,14 @@ unicode = 05F1;
 },
 {
 glyphname = "yodyod-hb";
-lastChange = "2016-07-07 21:10:59 +0000";
+lastChange = "2024-02-28 23:18:47 +0000";
 layers = (
 {
 anchors = (
+{
+name = bottom;
+position = "{327, 0}";
+},
 {
 name = caret_1;
 position = "{250, 0}";
@@ -38102,6 +38106,10 @@ width = 648;
 {
 anchors = (
 {
+name = bottom;
+position = "{308, 0}";
+},
+{
 name = caret_1;
 position = "{250, 0}";
 }
@@ -38120,6 +38128,10 @@ width = 580;
 },
 {
 anchors = (
+{
+name = bottom;
+position = "{366, 0}";
+},
 {
 name = caret_1;
 position = "{250, 0}";
@@ -38140,6 +38152,10 @@ width = 686;
 {
 anchors = (
 {
+name = bottom;
+position = "{176, 0}";
+},
+{
 name = caret_1;
 position = "{250, 0}";
 }
@@ -38159,6 +38175,10 @@ width = 358;
 {
 anchors = (
 {
+name = bottom;
+position = "{223, 0}";
+},
+{
 name = caret_1;
 position = "{250, 0}";
 }
@@ -38177,6 +38197,10 @@ width = 444;
 },
 {
 anchors = (
+{
+name = bottom;
+position = "{279, 0}";
+},
 {
 name = caret_1;
 position = "{250, 0}";


### PR DESCRIPTION
For all three families (Sans, Serif, Rashi) and across all layers, this commit adds the "bottom" anchor at the correct x position for double-yod and corrects it for double-vav. The adjustment ensures the x position is now accurately placed halfway between the bottom anchor's x position on each of the subletters, with the Y position at 0 (baseline).

Tested by regenerating TTFs via the Glyphs App (File > Export) for each family, then running hb-view commands ala instructions in issue, but extended test to every weight generated for all 3 families (Sans/Rashi/Serif).  Then visually inspected every resulting .png file, confirming the corrections were successful and visually consistent across all variants.